### PR TITLE
Point to main Software Carpentry site.

### DIFF
--- a/first-analysis-steps/README.md
+++ b/first-analysis-steps/README.md
@@ -12,7 +12,9 @@ If you have any problems or questions, you can [send an email to
 Before starting, you should be familiar with using a shell, like `bash`, and
 with programming in Python.
 
-The [Software Carpentry
-workshop](https://software-carpentry.org/lessons/) gives a great
-introduction to these, as well as to many other useful computing tools. The [Starterkit](https://lhcb.github.io/analysis-essentials/index.html) has some supplementary material as well.
+The [analysis essentials 
+course](https://lhcb.github.io/analysis-essentials/index.html) has an 
+introduction to these topics, as does the [Software Carpentry
+workshop](https://software-carpentry.org/lessons/), which includes many other 
+useful computing tools.
 {% endprereq %} 

--- a/first-analysis-steps/README.md
+++ b/first-analysis-steps/README.md
@@ -13,6 +13,6 @@ Before starting, you should be familiar with using a shell, like `bash`, and
 with programming in Python.
 
 The [Software Carpentry
-workshop](http://twitwi.github.io/2015-06-02-cern-lhcb/) gives a great
+workshop](https://software-carpentry.org/lessons/) gives a great
 introduction to these, as well as to many other useful computing tools. The [Starterkit](https://lhcb.github.io/analysis-essentials/index.html) has some supplementary material as well.
 {% endprereq %} 


### PR DESCRIPTION
Rather than pointing the site used for the LHCb workshop, link to the main SWC site.

Closes lhcb/starterkit#42.