### PR TITLE
Update DB Tags in DTF options file

### DIFF
--- a/first-analysis-steps/code/decay-tree-fitter/ntuple_DTF1.py
+++ b/first-analysis-steps/code/decay-tree-fitter/ntuple_DTF1.py
@@ -50,8 +50,8 @@ DaVinci().Simulation = True
 # Only ask for luminosity information when not using simulated data
 DaVinci().Lumi = not DaVinci().Simulation
 DaVinci().EvtMax = -1
-DaVinci().CondDBtag = 'sim-20170721-1-vc-mu100'
-DaVinci().DDDBtag = 'dddb-20171005-3'
+DaVinci().CondDBtag = 'sim-20161124-2-vc-md100'
+DaVinci().DDDBtag = 'dddb-20150724'
 
 # Use the local input data
 IOHelper().inputFiles([


### PR DESCRIPTION
Following on from #50 to make the DB tags match with the ones used when the MC was generated.