### PR TITLE
Remove some typing when opening TBrowser

### DIFF
--- a/first-analysis-steps/add-tupletools.md
+++ b/first-analysis-steps/add-tupletools.md
@@ -130,7 +130,7 @@ You will obtain a `DVntuple.root` file, which we can open and inspect with `ROOT
 $ root DVntuple.root
 root [0]
 Attaching file DVntuple.root as _file0...
-root [1] TBrowser *b = new TBrowser()
+root [1] TBrowser b
 root [2]
 ```
 


### PR DESCRIPTION
I think the `new` has no advantage here, and might even teach the not so good habit of many ROOT tutorials to excessively use `new`.