### PR TITLE
Explained how to pick up a proper platform

### DIFF
--- a/first-analysis-steps/davinci-grid.md
+++ b/first-analysis-steps/davinci-grid.md
@@ -62,6 +62,12 @@ ship it off to the grid.
 {% callout "Picking up a right platform" %}
 Early 2018, the default platform on most of lxplus machines was changed to `x86_64-slc6-gcc62-opt` (instead of `x86_64-slc6-gcc49-opt`), changing the version of the gcc compiler from 4.9 to 6.2. 
 However, most of older DaVinci versions, anterior to v42r0, are not compiled for `x86_64-slc6-gcc62-opt`. 
+
+The list of platforms available for a certain DaVinci version `vXrYpZ`, can be viewed by
+```bash
+$ ls /cvmfs/lhcb.cern.ch/lib/lhcb/DAVINCI/DAVINCI_vXrYpZ/InstallArea/
+```
+
 In case you have a strong reason to use one of these DaVinci versions, few additional actions are needed to set up your ganga job properly.
 
 First, outside ganga set up the necessary platform:

--- a/first-analysis-steps/davinci-grid.md
+++ b/first-analysis-steps/davinci-grid.md
@@ -59,6 +59,21 @@ running yet. To submit it type `j.submit()`. Now `ganga` will do the
 equivalent of `lb-run DaVinci/v42r6p1`, prepare your job and then
 ship it off to the grid.
 
+{% callout "Picking up a right platform" %}
+Early 2018, the default platform on most of lxplus machines was changed to `x86_64-slc6-gcc62-opt` (instead of `x86_64-slc6-gcc49-opt`), changing the version of the gcc compiler from 4.9 to 6.2. 
+However, most of ancient DaVinci versions, anterior to v42r0, are not compiled for `x86_64-slc6-gcc62-opt`. 
+In case you have a strong reason to use one of these DaVinci versions, few additional actions are needed to set up jour ganga job properly.
+
+First, outside ganga pick up the necessary platform:
+```bash
+$ LbLogin -c x86_64-slc6-gcc49-opt
+```
+Then, when setting up a ganga job, the following line should be added after declaring the `j.application`:
+```python
+j.application.platform = 'x86_64-slc6-gcc49-opt'
+```
+{% endcallout %} 
+
 While it runs, let's submit an identical job via slightly different
 method. Having to type in the details of each job every time you want
 to run it is error prone and tedious. Instead you can place all the

--- a/first-analysis-steps/davinci-grid.md
+++ b/first-analysis-steps/davinci-grid.md
@@ -61,14 +61,14 @@ ship it off to the grid.
 
 {% callout "Picking up a right platform" %}
 Early 2018, the default platform on most of lxplus machines was changed to `x86_64-slc6-gcc62-opt` (instead of `x86_64-slc6-gcc49-opt`), changing the version of the gcc compiler from 4.9 to 6.2. 
-However, most of ancient DaVinci versions, anterior to v42r0, are not compiled for `x86_64-slc6-gcc62-opt`. 
-In case you have a strong reason to use one of these DaVinci versions, few additional actions are needed to set up jour ganga job properly.
+However, most of older DaVinci versions, anterior to v42r0, are not compiled for `x86_64-slc6-gcc62-opt`. 
+In case you have a strong reason to use one of these DaVinci versions, few additional actions are needed to set up your ganga job properly.
 
-First, outside ganga pick up the necessary platform:
+First, outside ganga set up the necessary platform:
 ```bash
 $ LbLogin -c x86_64-slc6-gcc49-opt
 ```
-Then, when setting up a ganga job, the following line should be added after declaring the `j.application`:
+Then, when setting up your ganga job, add the following line after declaring the `j.application`:
 ```python
 j.application.platform = 'x86_64-slc6-gcc49-opt'
 ```

--- a/first-analysis-steps/davinci-grid.md
+++ b/first-analysis-steps/davinci-grid.md
@@ -63,9 +63,9 @@ ship it off to the grid.
 Early 2018, the default platform on most of lxplus machines was changed to `x86_64-slc6-gcc62-opt` (instead of `x86_64-slc6-gcc49-opt`), changing the version of the gcc compiler from 4.9 to 6.2. 
 However, most of older DaVinci versions, anterior to v42r0, are not compiled for `x86_64-slc6-gcc62-opt`. 
 
-The list of platforms available for a certain DaVinci version `vXrYpZ`, can be viewed by
+The list of platforms available for a certain DaVinci version (let's say `v38r0`), can be viewed by
 ```bash
-$ ls /cvmfs/lhcb.cern.ch/lib/lhcb/DAVINCI/DAVINCI_vXrYpZ/InstallArea/
+$ lb-sdb-query listPlatforms DaVinci v38r0
 ```
 
 In case you have a strong reason to use one of these DaVinci versions, few additional actions are needed to set up your ganga job properly.


### PR DESCRIPTION
Following numerous problems from users trying to set up a ganga job using ancient DaVinci versions, a short tutorial on overcoming these issues was added.