### PR TITLE
Changed decay tree descriptors and substitutions to comply to new ref…

### DIFF
--- a/second-analysis-steps/code/18-switch-mass-hypo/ntuple_switchHypo.py
+++ b/second-analysis-steps/code/18-switch-mass-hypo/ntuple_switchHypo.py
@@ -6,7 +6,7 @@ from DecayTreeTuple.Configuration import *
 
 # Stream and stripping line we want to use
 stream = 'AllStreams'
-line = 'D2hhCompleteEventPromptDst2D2RSLine'
+line = 'D2hhPromptDst2D2KKLine'
 tesLoc = '/Event/{0}/Phys/{1}/Particles'.format(stream, line)
 
 # get the selection(s) created by the stripping
@@ -15,18 +15,19 @@ strippingSels = [DataOnDemand(Location=tesLoc)]
 # configure an algorithm to substitute the Kaon in the D0-decay by a second
 # pion
 subs = SubstitutePID(
-    'MakeD02pipi',
-    Code="DECTREE('[D*(2010)+ -> (D0 -> K- pi+) pi+]CC')",
+    'MakeD02Kpi',
+    Code="DECTREE('[D*(2010)+ -> (D0 -> K- K+) pi+]CC')",
     # note that SubstitutePID can't handle automatic CC
     Substitutions={
-        'Charm -> (D0 -> ^K- pi+) Meson': 'pi-',
-        'Charm -> (D~0 -> ^K+ pi-) Meson': 'pi+'
-    }
+        'Charm -> (D0 -> ^K- K+) Meson': 'pi-',
+        'Charm -> (D0 -> K- ^K+) Meson': 'pi+',
+        'Charm -> (D~0 -> ^K- K+) Meson': 'pi-',
+        'Charm -> (D~0 -> K- ^K+) Meson': 'pi+'}
 )
 
 # create a selection using the substitution algorithm
 selSub = Selection(
-    'Dst2D0pi_D02pipi_Sel',
+    'Dst2D0pi_D02Kpi_Sel',
     Algorithm=subs,
     RequiredSelections=strippingSels
 )
@@ -35,9 +36,9 @@ selSeq = SelectionSequence('SelSeq', TopSelection=selSub)
 
 
 # Create an ntuple to capture D*+ decays from the new selection
-dtt = DecayTreeTuple('TupleDstToD0pi_D0Topipi')
+dtt = DecayTreeTuple('TupleDstToD0pi_D0ToKpi')
 dtt.Inputs = [selSeq.outputLocation()]
-dtt.Decay = '[D*(2010)+ -> ^(D0 -> ^pi- ^pi+) ^pi+]CC'
+dtt.Decay = '[D*(2010)+ -> ^(D0 -> ^K- ^pi+) ^pi+]CC'
 
 # Configure DaVinci
 
@@ -50,7 +51,7 @@ DaVinci().appendToMainSequence([seq])
 DaVinci().InputType = 'DST'
 DaVinci().TupleFile = 'DVntuple.root'
 DaVinci().PrintFreq = 1000
-DaVinci().DataType = '2012'
+DaVinci().DataType = '2016'
 DaVinci().Simulation = True
 # Only ask for luminosity information when not using simulated data
 DaVinci().Lumi = not DaVinci().Simulation
@@ -58,5 +59,5 @@ DaVinci().EvtMax = -1
 
 # Use the local input data
 IOHelper().inputFiles([
-    './00035742_00000002_1.allstreams.dst'
+    './00062514_00000001_7.AllStreams.dst'
 ], clear=True)

--- a/second-analysis-steps/code/18-switch-mass-hypo/ntuple_switchHypo.py
+++ b/second-analysis-steps/code/18-switch-mass-hypo/ntuple_switchHypo.py
@@ -19,10 +19,8 @@ subs = SubstitutePID(
     Code="DECTREE('[D*(2010)+ -> (D0 -> K- K+) pi+]CC')",
     # note that SubstitutePID can't handle automatic CC
     Substitutions={
-        'Charm -> (D0 -> ^K- K+) Meson': 'pi-',
         'Charm -> (D0 -> K- ^K+) Meson': 'pi+',
-        'Charm -> (D~0 -> ^K- K+) Meson': 'pi-',
-        'Charm -> (D~0 -> K- ^K+) Meson': 'pi+'}
+        'Charm -> (D~0 -> ^K- K+) Meson': 'pi-'}
 )
 
 # create a selection using the substitution algorithm

--- a/second-analysis-steps/switch-mass-hypo.md
+++ b/second-analysis-steps/switch-mass-hypo.md
@@ -13,20 +13,18 @@ stripping has already found.  However, you can reinterpret parts of the decay
 to look for new decay modes.
 {% endcallout %}
 
-As an example we will switch the decays of the D0 and D~0 from (K K) to (K pi). 
+As an example we will switch the decays of the D0 from (K- K+) to (K- pi+). 
 
 There is an algorithm that allows us to replace parts of the decay descriptor called `SubstitutePID`:
 
 ```python
-# configure an algorithm to substitute one of the kaons in the D0 (resp D~0) decay by a pion 
+# configure an algorithm to substitute the K+ in the D0 (resp the K- in the D~0) decay by a pion 
 from Configurables import SubstitutePID
 subs = SubstitutePID(
     'MakeD02Kpi',
     Code = "DECTREE('[D*(2010)+ -> (D0 -> K- K+) pi+]CC')",
     # note that SubstitutePID can't handle automatic CC
     Substitutions = {
-    'Charm -> (D0 -> ^K- K+) Meson': 'pi-',
-    'Charm -> (D~0 -> ^K+ K-) Meson': 'pi+',
     'Charm -> (D0 -> K- ^K+) Meson': 'pi+',
     'Charm -> (D~0 -> K+ ^K-) Meson': 'pi-'}
 )
@@ -36,9 +34,9 @@ The algorithm is configured with a name `MakeD02Kpi`. In the `Code` argument we 
 
 Now we ware ready to specify which hypotheses to change. `Substitutions` is a dictionary where the keys are decay descriptors and the values are the names of the replacement particles. The particle that should be replaced is marked with a `^`. So in the example above
 ```python
-'Charm -> (D0 -> ^K- K+) Meson': 'pi-'
+'Charm -> (D0 -> K- ^K+) Meson': 'pi+'
 ```
-means: Look for a decay of a Charm-particle into D0 plus any meson, where the D0 decays to (K- K+) and replace the K- with a pi-.
+means: Look for a decay of a Charm-particle into D0 plus any meson, where the D0 decays to (K- K+) and replace the K+ with a pi+.
 
 Note that `SubstitutePID` does not automatically handle complex conjugation via the `CC` operator. Therefore you have to specify all substitutions explicitely. 
 

--- a/second-analysis-steps/switch-mass-hypo.md
+++ b/second-analysis-steps/switch-mass-hypo.md
@@ -13,31 +13,32 @@ stripping has already found.  However, you can reinterpret parts of the decay
 to look for new decay modes.
 {% endcallout %}
 
-As an example we will switch the decay of the D0 from (K pi) to (pi pi). 
+As an example we will switch the decays of the D0 and D~0 from (K K) to (K pi). 
 
 There is an algorithm that allows us to replace parts of the decay descriptor called `SubstitutePID`:
 
 ```python
-# configure an algorithm to substitute the Kaon in the D0-decay by a second pion 
+# configure an algorithm to substitute one of the kaons in the D0 (resp D~0) decay by a pion 
 from Configurables import SubstitutePID
 subs = SubstitutePID(
-    'MakeD02pipi',
-    Code = "DECTREE('[D*(2010)+ -> (D0 -> K- pi+) pi+]CC')",
+    'MakeD02Kpi',
+    Code = "DECTREE('[D*(2010)+ -> (D0 -> K- K+) pi+]CC')",
     # note that SubstitutePID can't handle automatic CC
     Substitutions = {
-        'Charm -> (D0 -> ^K- pi+) Meson': 'pi-',
-        'Charm -> (D0 -> ^K+ pi-) Meson': 'pi+'
-    }
+    'Charm -> (D0 -> ^K- K+) Meson': 'pi-',
+    'Charm -> (D~0 -> ^K+ K-) Meson': 'pi+',
+    'Charm -> (D0 -> K- ^K+) Meson': 'pi+',
+    'Charm -> (D~0 -> K+ ^K-) Meson': 'pi-'}
 )
 ```
 
-The algorithm is configured with a name `MakeD02pipi`. In the `Code` argument we need to specify the initial selection. This is done by using LoKi functors. Since we know we will be using an already prepared selection, we can simply use the `DECTREE` functor to search for candidates fulfilling this decay structure. See the [lesson on LoKi](../first-analysis-steps/loki-functors.md) for more info on what you can do here. 
+The algorithm is configured with a name `MakeD02Kpi`. In the `Code` argument we need to specify the initial selection. This is done by using LoKi functors. Since we know we will be using an already prepared selection, we can simply use the `DECTREE` functor to search for candidates fulfilling this decay structure. See the [lesson on LoKi](../first-analysis-steps/loki-functors.md) for more info on what you can do here. 
 
 Now we ware ready to specify which hypotheses to change. `Substitutions` is a dictionary where the keys are decay descriptors and the values are the names of the replacement particles. The particle that should be replaced is marked with a `^`. So in the example above
 ```python
-'Charm -> (D0 -> ^K- pi+) Meson': 'pi-'
+'Charm -> (D0 -> ^K- K+) Meson': 'pi-'
 ```
-means: Look for a decay of a Charm-particle into D0 plus any meson, where the D0 decays to (K- pi+) and replace the K- with a pi-.
+means: Look for a decay of a Charm-particle into D0 plus any meson, where the D0 decays to (K- K+) and replace the K- with a pi-.
 
 Note that `SubstitutePID` does not automatically handle complex conjugation via the `CC` operator. Therefore you have to specify all substitutions explicitely. 
 
@@ -49,7 +50,7 @@ from PhysSelPython.Wrappers import DataOnDemand
 
 # Stream and stripping line we want to use
 stream = 'AllStreams'
-line = 'D2hhCompleteEventPromptDst2D2RSLine'
+line = 'D2hhPromptDst2D2KKLine'
 tesLoc = '/Event/{0}/Phys/{1}/Particles'.format(stream, line)
 
 # get the selection(s) created by the stripping
@@ -61,7 +62,7 @@ The output of the algorithm has to be packaged into a new selection:
 ```python
 # create a selection using the substitution algorithm
 selSub = Selection(
-    'Dst2D0pi_D02pipi_Sel',
+    'Dst2D0pi_D02Kpi_Sel',
     Algorithm=Subs,
     RequiredSelections=strippingSels
 )
@@ -76,10 +77,10 @@ selSeq = SelectionSequence('SelSeq', TopSelection=selSub)
 We are now ready to produce an ntuple on our newly created selection. As usual we configure a `DecayTreeTuple`, which now is looking for the candidates, which have the redefined D0 decay:
 ```python
 # Create an ntuple to capture D*+ decays from the new selection
-dtt = DecayTreeTuple('TupleDstToD0pi_D0Topipi')
+dtt = DecayTreeTuple('TupleDstToD0pi_D0ToKpi')
 dtt.Inputs = [selSeq.outputLocation()]
 # note the redefined decay of the D0
-dtt.Decay = '[D*(2010)+ -> ^(D0 -> ^pi- ^pi+) ^pi+]CC'
+dtt.Decay = '[D*(2010)+ -> ^(D0 -> ^K- ^pi+) ^pi+]CC'
 ```
 
 The input to the `DecayTreeTuple` is taken as the `outputLocations` of the `SelectionSequence` we just created. 


### PR DESCRIPTION
… sample

Here, the decay descriptor and the mass substitutions have to be checked carefully by reviewers because of the presence of D0s.