### PR TITLE
Fixed decay descriptor to match all others in repo

### DIFF
--- a/second-analysis-steps/filter-in-trees.md
+++ b/second-analysis-steps/filter-in-trees.md
@@ -35,7 +35,7 @@ from PhysSelPython.Wrappers import Selection, DataOnDemand
 
 Pions = DataOnDemand('Phys/StdAllNoPIDsPions/Particles')
 kst = CombineParticles('kst_particles',
-                       DecayDescriptor=['[K*(892)0 -> K+ pi-]CC'],
+                       DecayDescriptor="[K*(892)0 -> K+ pi-]cc",
                        CombinationCut="ADAMASS('K*(892)0') < 300*MeV",
                        MotherCut='(VFASPF(VCHI2/VDOF)< 9)')
 kst_sel = Selection('kst_sel',


### PR DESCRIPTION
I replaced CC by cc because it's the way it's written in the following of the lesson and also in the "build your own decay" lesson.