### PR TITLE
Update the info on registering a laptop

### DIFF
--- a/first-analysis-steps/prerequisites.md
+++ b/first-analysis-steps/prerequisites.md
@@ -20,7 +20,7 @@ a computer. There will be no machines for you to use in the room.
 > your desktop or someone else's computer.
 
 If this is the first time you are bringing your laptop to CERN, you
-will have to [register it](https://network.cern.ch) before it can
+will have to [register it](http://information-technology.web.cern.ch/help/connect-your-device) before it can
 access the internet.
 
 Please bring your power supply, as well as a plug adaptor to Swiss and European plugs.


### PR DESCRIPTION
The old link works only when connecting from the CERN network.
Replaced by the one with more explanations