### PR TITLE
Reference to twiki for details on some of the fast simulation options

### DIFF
--- a/second-analysis-steps/simulation-fastsim.md
+++ b/second-analysis-steps/simulation-fastsim.md
@@ -32,6 +32,7 @@ Allows to re-use the underlying event but generates and simulates new signal dec
 speed-ups by a factor between 10 and 20 are typically seen. Additionally, the same precision as in the nominal simulation is reached.
 However, as the underlying event and the kinematics of the signal particle remain unchanged, correlations between different events are introduced whose
 effect depends on the studied observables and need to be handled with care if significant.
+See also https://twiki.cern.ch/twiki/bin/view/LHCb/ReDecay.
 
 ## Speeding up the generation
 
@@ -42,3 +43,4 @@ to split the generator cuts: One part is applied as usual, triggering a reset of
 EvtGen generated the signal decay. If the generated decay fails (e.g. the invariant mass combination of two children is below a threshold), the decay products are
 removed and a new decay is generated until the cuts are passed. This avoids rerunning Pythia unnecessarily and can lead to substantial CPU savings when studying rare
 particles (e.g. $$\Lambda_b$$).
+For implementation details, see https://twiki.cern.ch/twiki/bin/view/LHCb/GeneratorLevelEvtGenCuts

--- a/second-analysis-steps/simulation-gencuts.md
+++ b/second-analysis-steps/simulation-gencuts.md
@@ -69,6 +69,7 @@ the entire generation phase of the simulation. Therefore, very tight generator l
 with a signal particle that only rarely occurs in minimum bias events can results in the generation phase
 taking manifold longer than the simulation of the detector response (and you might want to rethink your
 strategy for event generation).
+For some ideas on which kind of cuts to apply, you can have a look here: https://twiki.cern.ch/twiki/bin/view/LHCb/GeneratorLevelTightCuts
 
 {% callout "Modifying cut tools for production" %}
 As the cut tools are to be configured in the DecFiles, they form an integral part of the event-type itself.


### PR DESCRIPTION
Discussing on mattermost, it was clear that the starterkit does not reference directly the more detailed documentation on some fast simulation options. For that reason, I have added a few references to these two simulation lessons, so people can find the implementation details if they want to know more.