### PR TITLE
Fix bug in dosometing_py example script for snakemake

### DIFF
--- a/second-analysis-steps/analysis-automation-snakemake.md
+++ b/second-analysis-steps/analysis-automation-snakemake.md
@@ -225,8 +225,8 @@ rule dosomething_py:
     input: 'myfile.txt'
     output: 'myoutput.txt'
     run:
-        with open(input, 'rt') as fi:
-            with open(output, 'wt') as fo:
+        with open(str(input), 'rt') as fi:
+            with open(str(output), 'wt') as fo:
                 fo.write(fi.read())
 ```
 


### PR DESCRIPTION
Fixes bug discussed on Mattermost starterkit channel where the script fails with error
```
TypeError in line 5 of /.../Snakefile:
expected str, bytes or os.PathLike object, not InputFiles
```

Use str to convert the filename variables from type InputFiles/OutputFiles to str.