### PR TITLE
Fix prerequisites for `lxplus7`

### DIFF
--- a/first-analysis-steps/prerequisites.md
+++ b/first-analysis-steps/prerequisites.md
@@ -76,9 +76,8 @@ Try the following steps with the computer you will use at the workshop:
    /DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=thead/CN=667505/CN=Timothy Daniel Head | private_pilot | 2015/08/25 08:05
   ```
 
- 4. Check that X11 forwarding works by typing `xeyes` on lxplus. A set
-    of eyes following your mouse should appear on your screen. Press
-    `Ctrl-C` from the terminal to exit.
+ 4. Check that X11 forwarding works by typing `glxgears` on lxplus. Some rotating gears should appear in 
+    a new window. Press `Ctrl-C` from the terminal to exit.
     >If you're not connected to the CERN network at CERN, do not worry if the X11 forwarding is slow--this is normal.
 
 If you can successfully execute all of the above steps, you are ready to go for


### PR DESCRIPTION
`xeyes` is not installed on `lxplus7`, so it can not be used to test whether X11 forwarding works. `glxgears` should be installed virtually anywhere X11 is installed, so should be a more robust option, but we could choose any command using X11 available on `lxplus6` and `lxplus7`.