### PR TITLE
Remove recommonmark hack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ cache: false
 dist: xenial
 
 install:
-  # FIXME: Inline math is broken in upstream recommonmark
-  - pip install git+https://github.com/chrisburr/recommonmark.git@patch-1
-  - pip install -vv starterkit-ci>=0.0.10
+  - pip install -vv starterkit-ci>=0.1.0
 
 script:
   - starterkit_ci build


### PR DESCRIPTION
No longer required. See https://github.com/lhcb/starterkit-ci/pull/1 for details.