### PR TITLE
Add extra missing turbo option

### DIFF
--- a/first-analysis-steps/analysis-productions.md
+++ b/first-analysis-steps/analysis-productions.md
@@ -93,6 +93,7 @@ defaults:
     application: DaVinci/v45r5
     wg: Charm
     automatically_configure: yes
+    turbo: no
     inform:
         - your.email.here@cern.ch
     options:


### PR DESCRIPTION
378db0b added a `turbo` option for `info.yaml` files in the Analysis Production lesson, but the one in the main lesson was missed