### PR TITLE
Fix lb-run environment issues when running with ipython

### DIFF
--- a/first-analysis-steps/interactive-dst.md
+++ b/first-analysis-steps/interactive-dst.md
@@ -50,7 +50,7 @@ Place this into a file called `first.py` and run the following
 command in a new terminal:
 
 ```bash
-$ lb-run DaVinci/v45r1 ipython -i first.py 00070793_00000001_7.AllStreams.dst
+$ lb-run --ext=ipython DaVinci/v45r1 ipython -i first.py 00070793_00000001_7.AllStreams.dst
 ```
 
 This will open the DST and print out some of the TES locations

--- a/first-analysis-steps/loki-functors.md
+++ b/first-analysis-steps/loki-functors.md
@@ -45,7 +45,7 @@ left off [exploring a DST interactively](interactive-dst).
 First open the DST as we did previously:
 
 ```bash
-$ lb-run DaVinci/v45r1 ipython -i first.py 00070793_00000001_7.AllStreams.dst
+$ lb-run --ext=ipython DaVinci/v45r1 ipython -i first.py 00070793_00000001_7.AllStreams.dst
 ```
 
 Get the first candidate in the `D2hhPromptDst2D2KKLine` line:


### PR DESCRIPTION
closes #232

Other calls to `lb-run DaVinci/v45r1` should also be checked, but this particular line needs fixing.

Alternatively this line could be changed to use `python` instead of `ipython`, but the interactive-ness of `ipython` seems like a helpful asset in this context.

I would also perhaps like to change some of the python syntax used throughout this section to conform to python 3 syntax. 

For example
```python
print tracks[0]
```

should really be
```python
print(tracks[0])
```
so new users don't get too familiar with old Python 2 syntax. perhaps that is another pull request