### PR TITLE
Replace lb-run LHCbDirac with lb-dirac

### DIFF
--- a/first-analysis-steps/files-from-grid.md
+++ b/first-analysis-steps/files-from-grid.md
@@ -36,7 +36,7 @@ Initialisation of the proxy might take a while and should ask you for your certi
 Once we have a working Dirac installation, getting the file is as easy as
 
 ```bash
-lb-run LHCbDIRAC dirac-dms-get-file LFN:/lhcb/MC/2016/ALLSTREAMS.DST/00070793/0000/00070793_00000001_7.AllStreams.dst
+lb-dirac dirac-dms-get-file LFN:/lhcb/MC/2016/ALLSTREAMS.DST/00070793/0000/00070793_00000001_7.AllStreams.dst
 ```
 
 Again this will take a while but afterwards you should have a file called `00070793_00000001_7.AllStreams.dst` in the directory where you called the command.
@@ -64,7 +64,7 @@ XML catalog such that it can access them remotely.
 
 First generate the XML catalog with
 ```bash
-lb-run LHCbDIRAC dirac-bookkeeping-genXMLCatalog --Options=MC_2016_27163002_Beam6500GeV2016MagDownNu1.625nsPythia8_Sim09c_Trig0x6138160F_Reco16_Turbo03_Stripping28r1NoPrescalingFlagged_ALLSTREAMS.DST.py --Catalog=myCatalog.xml
+lb-dirac dirac-bookkeeping-genXMLCatalog --Options=MC_2016_27163002_Beam6500GeV2016MagDownNu1.625nsPythia8_Sim09c_Trig0x6138160F_Reco16_Turbo03_Stripping28r1NoPrescalingFlagged_ALLSTREAMS.DST.py --Catalog=myCatalog.xml
 ```
 and add
 ```python
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     print('Done getting {0} files.'.format(n_files))
 ```
 
-Save it as `getEvents.py` and use it via `lb-run LHCbDIRAC python getEvents.py [n]`. If you specify `n`, the script will only get the first n files from the grid.
+Save it as `getEvents.py` and use it via `lb-dirac python getEvents.py [n]`. If you specify `n`, the script will only get the first n files from the grid.
 
 {% callout "Such a clever script!" %}
 
@@ -106,7 +106,7 @@ Save it as `getEvents.py` and use it via `lb-run LHCbDIRAC python getEvents.py [
 extract the LFNs from any file
 and download them for you. So a simple
 ```python
- lb-run LHCbDIRAC dirac-dms-get-file --File=MC_2016_27163002_Beam6500GeV2016MagDownNu1.625nsPythia8_Sim09c_Trig0x6138160F_Reco16_Turbo03_Stripping28r1NoPrescalingFlagged_ALLSTREAMS.DST.py
+ lb-dirac dirac-dms-get-file --File=MC_2016_27163002_Beam6500GeV2016MagDownNu1.625nsPythia8_Sim09c_Trig0x6138160F_Reco16_Turbo03_Stripping28r1NoPrescalingFlagged_ALLSTREAMS.DST.py
 ```
 would do to download them all!
 


### PR DESCRIPTION
Replace all instances of `lb-run LHCbDirac` with `lb-dirac`, as the former is no longer available.