### PR TITLE
Update DST exploration lesson

### DIFF
--- a/first-analysis-steps/interactive-dst.md
+++ b/first-analysis-steps/interactive-dst.md
@@ -12,7 +12,7 @@
 
 Data is stored in files called DSTs, which are processed
 by DaVinci to make nTuples. However you can also explore
-them interactively from a python session.
+them interactively from a Python session.
 
 This is particularly useful if you want to quickly find
 something out, or the more complex processing in DaVinci
@@ -20,7 +20,8 @@ is not working as expected.
 
 The file we [downloaded from the grid](files-from-grid)
 contains simulated data, with stripping and trigger decisions
-and so on. Here we assumed the file you downloaded is called `00070793_00000001_7.AllStreams.dst`.
+and so on. In this lesson we assume the file you downloaded is called `00070793_00000001_7.AllStreams.dst`.
+
 To take a look at the contents of the TES, we need to write a small
 Python file:
 
@@ -35,7 +36,7 @@ dv = DaVinci()
 dv.DataType = '2016'
 dv.Simulation = True
 
-# Pass file to open as first command line argument
+# Retrieve file path to open as the last command line argument
 inputFiles = [sys.argv[-1]]
 IOHelper('ROOT').inputFiles(inputFiles)
 
@@ -43,91 +44,102 @@ appMgr = GP.AppMgr()
 evt = appMgr.evtsvc()
 
 appMgr.run(1)
-evt.dump()
 ```
 
-Place this into a file called `first.py` and run the following
+We first configure the application using the `DaVinci` configurable, set up
+the input data, and then create the application manager and tell it to start
+running.
+
+Place this into a file called `explore.py` and run the following
 command in a new terminal:
 
 ```bash
-$ lb-run --ext=ipython DaVinci/v45r1 ipython -i first.py 00070793_00000001_7.AllStreams.dst
+$ lb-run --ext=ipython DaVinci/v45r1 ipython -i explore.py 00070793_00000001_7.AllStreams.dst
 ```
 
-This will open the DST and print out some of the TES locations
-which exist for this event. We are now ready to explore the TES,
-which is accessible via the `evt` variable. For example you could
-look at the properties of some tracks for the first event by typing
-inside the python session:
+This will configure the application, initialise it, and put you in a Python
+prompt. We are now ready to explore the TES, which is accessible via the
+`evt` variable. We can start by printing out some of the TES locations which
+exist for this event.
 
 ```python
-tracks = evt['/Event/Rec/Track/Best']
-print(tracks[0])
+>>> evt.dump()
 ```
 
-The next question is, how do you know what TES locations that could
-exist? As we saw `evt.dump()` prints a few of them, but not all. In
-addition there are some special ones that only exist if you try to
-access them. The following snippet allows you to discover most TES
-locations that are interesting:
+You could look at the properties of some tracks in the first event by typing
+inside the Python session:
 
 ```python
-def nodes(evt, node=None):
-    """List all nodes in `evt`"""
-    nodenames = []
-
-    if node is None:
-        root = evt.retrieveObject('')
-        node = root.registry()
-
-    if node.object():
-        nodenames.append(node.identifier())
-        for l in evt.leaves(node):
-            # skip a location that takes forever to load
-            # XXX How to detect these automatically??
-            if 'Swum' in l.identifier():
-                continue
-
-            temp = evt[l.identifier()]
-            nodenames += nodes(evt, l)
-
-    else:
-        nodenames.append(node.identifier())
-
-    return nodenames
+>>> tracks = evt['/Event/Rec/Track/Best']
+>>> print(tracks[0])
 ```
 
-The easiest way to use it is to add it to your `first.py` script
-and re-run it as before. Then, in your iPython session, enter `nodes(evt)`.
-This will list a large number of TES locations, but even so there
-are some which you have to know about. Another oddity is that some
-locations are 'packed', for example: `/Event/AllStreams/pPhys/Particles`.
-You can not access these directly at this location. Instead you
-have to know what location the contents will get unpacked to when
-you want to use it. Often you can just try removing the small `p`
-from the location (`/Event/AllStreams/Phys/Particles`).
+The next question is, how do you know what TES locations that could exist? As
+we saw `evt.dump()` prints a few of them, but not all, including
+`/Event/Rec/Track/Best`.
 
-You can also inspect the particles and vertices built by your stripping
-line. However not every event will contain a candidate for your line,
-so the first tool we need is something that will advance us until
-the stripping decision was positive:
+We can use the directory-like structure of the TES to walk through the
+hierachy from the root node.
+
+```python
+>>> root = TES['/Event']
+>>> evt.leaves(root)
+<ROOT.vector<IRegistry*> object at 0x11d1deb0
+>>> root_children = evt.leaves()
+>>> root_children.size()
+23L
+>>> root_children[0]
+<ROOT.DataSvcHelpers::RegistryEntry object at 0x126576b0>
+>>> root_children[0].identifier()
+'/Event/Gen'
+```
+
+So from the `root` node we can find the locations of the children! We can put
+this into a little recursive function that walks through all children of the
+root, all the children of each child, and so on.
+
+```python
+def nodes(evt, root='/Event'):
+    """List all nodes in `evt` starting from `node`."""
+    node_list = [root]
+    for leaf in evt.leaves(evt[root]):
+        node_list += nodes(evt, leaf.identifier())
+    return node_list
+```
+
+The easiest way to use this is to add it to your `explore.py` script
+and re-run as before. Then, in your IPython session, enter `nodes(evt)`.
+
+This will list a large number of TES locations which are present in the input
+file. But it still doesn't show `/Event/Rec/Track/Best`! Why not?
+
+This is because locations can be created _on demand_, only created when we
+first try to access them. Such locations are typically 'packed' in the input
+file, for example: `/Event/pRec/Track/Best`. The objects inside these packed
+locations get 'unpacked' to some other location, which happens auto-magically
+when you try to access the _unpacked_ location. Often you can just try
+removing the small `p` from the location (`/Event/Rec/Track/Best`) to trigger
+the unpacking. Other times you have to make sure the application is correctly
+configured to enable unpacking.
+
+
+You can also inspect the particles and vertices built by your stripping line.
+However not every event will contain a candidate for your line, so the second
+tool we need is something that will advance us through events until the
+stripping decision was positive:
 
 ```python
 def advance(decision):
     """Advance until stripping decision is true, returns
     number of events by which we advanced"""
     n = 0
-    while True:
+    while evt['/Event']:
+        reports = evt['/Event/Strip/Phys/DecReports']
+        if reports.hasDecisionName('Stripping{}Decision'.format(decision)):
+            break
+
         appMgr.run(1)
-
-        if not evt['/Event/Rec/Header']:
-            print('Reached end of input files')
-            break
-
         n += 1
-        dec=evt['/Event/Strip/Phys/DecReports']
-        if dec.hasDecisionName('Stripping{0}Decision'.format(decision)):
-            break
-
     return n
 ```
 
@@ -135,11 +147,10 @@ Add this to your script and restart `ipython` as before.
 
 {% callout "Detecting file ends" %}
 
-It is not easy to detect that the input file has ended. Especially
-if you want to get it right for data and simulation. Checking that
-`/Event/Rec/Header` exists is a safe bet in simulation and data if
-your file has been processed by `Brunel` (the event reconstruction
-software). It might not work in other cases.
+To avoid an infinite loop, we check that we still have events to process by
+seeing if `evt['/Event']` exists. This root location is present in every
+event in the input file; if it doesn't exist, we've run out of events to
+process.
 
 {% endcallout %} 
 
@@ -147,22 +158,22 @@ Using the name of our stripping line we can now advance through the
 DST until we reach an event which contains a candidate:
 
 ```python
-line = 'D2hhPromptDst2D2KKLine'
-advance(line)
+>>> line = 'D2hhPromptDst2D2KKLine'
+>>> advance(line)
 ```
 
 The candidates built for you can now be found at `/Event/AllStreams/Phys/D2hhPromptDst2D2KKLine/Particles`:
 
 ```python
-cands = evt['/Event/AllStreams/Phys/{0}/Particles'.format(line)]
-print(cands.size())
+>>> cands = evt['/Event/AllStreams/Phys/{}/Particles'.format(line)]
+>>> print(cands.size())
 ```
 
 This tells you how many candidates there are in this event and you can access the first
 one with:
 
 ```python
-print(cands[0])
+>>> print(cands[0])
 ```
 
 Which will print out some information about the [Particle](https://lhcb-doxygen.web.cern.ch/lhcb-doxygen/davinci/latest/d0/d13/class_l_h_cb_1_1_particle.html). In our case a `$ D^{* +} $` ([particle ID number](http://pdg.lbl.gov/2019/reviews/rpp2018-rev-monte-carlo-numbering.pdf) 413). You can access its daughters with
@@ -173,10 +184,11 @@ There is a useful tool for printing out decay trees, which you can
 pass the top level particle to and it will print out the daughters etc:
 
 ```python
-print_decay = appMgr.toolsvc().create(
-  'PrintDecayTreeTool', interface='IPrintDecayTreeTool'
-)
-print_decay.printTree(cands[0])
+>>> print_decay = appMgr.toolsvc().create(
+...   'PrintDecayTreeTool', interface='IPrintDecayTreeTool'
+... )
+...
+>>> print_decay.printTree(cands[0])
 ```
 
 With our candidates in hand, it would be nice to be able to retrieve and
@@ -213,5 +225,17 @@ The `-f` option tells `Bender` to try and "unpack" the locations such as
 `/Event/AllStreams/pPhys/Particles` that we mentioned above, while `-n 100`
 tells it to only process the first 100 events on the `DST`.
 Give this a try if you're ever stuck figuring out where your candidates are hiding!
+
+{% endcallout %} 
+
+
+{% callout "Configuration debugging" %}
+
+You can run an interactive exploration session using whatever application
+configuration you like, which can come in handy if your `DecayTreeTuple`
+isn't behaving how you expect.
+
+As long as all your configuration comes before the `GP.AppMgr()` line, that
+configuration will be included in the exploration session.
 
 {% endcallout %} 

--- a/first-analysis-steps/loki-functors.md
+++ b/first-analysis-steps/loki-functors.md
@@ -45,7 +45,7 @@ left off [exploring a DST interactively](interactive-dst).
 First open the DST as we did previously:
 
 ```bash
-$ lb-run --ext=ipython DaVinci/v45r1 ipython -i first.py 00070793_00000001_7.AllStreams.dst
+$ lb-run --ext=ipython DaVinci/v45r1 ipython -i explore.py 00070793_00000001_7.AllStreams.dst
 ```
 
 Get the first candidate in the `D2hhPromptDst2D2KKLine` line:


### PR DESCRIPTION
A few things:

- Rename file to `explore.py`, from `first.py`.
- Expand on the idea of packed versus unpacked locations.
- Expand on how we can walk through the TES, cleaning up the `node`
  method.
- Use an interactive Python prompt in the code examples.
- Add a call-out highlighting that the concepts can be used to debug any
  options.