### PR TITLE
Add glossary link to main left-menu panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ If you'd just like to learn about how to use the LHCb software, [read on](first-
 
     Analysis essentials <https://hsf-training.github.io/analysis-essentials/>
     LHCb Core documentation <https://cern.ch/lhcb-core-doc/>
+    LHCb glossary <https://lhcb.github.io/glossary/>
 ```


### PR DESCRIPTION
Minimalistically addressing https://github.com/lhcb/starterkit-lessons/issues/179. The bulk remains to be done, meaning the actual usage of the glossary inside the lectures.