### PR TITLE
fix 404 error

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -24,9 +24,9 @@ html_static_path += [
     f'_static',
 ]
 
+# Links to be ignored by the CI check
 linkcheck_ignore += [
-    r'https://groups\.cern\.ch/group/lhcb-distributed-analysis/default\.aspx',
-    'https://information-technology.web.cern.ch/services/batch',
+    r'https://groups\.cern\.ch/group/lhcb-distributed-analysis/default\.aspx'  # 403 error, requires a login
 ]
 
 starterkit_ci_redirects['first-analysis-steps/index.html'] = 'https://lhcb.github.io/starterkit-lessons/first-analysis-steps/README.html'

--- a/second-analysis-steps/managing-files-with-ganga.md
+++ b/second-analysis-steps/managing-files-with-ganga.md
@@ -289,6 +289,6 @@ depends on where the input files are.
 
 {% endcallout %}
 
-[batch]: https://information-technology.web.cern.ch/services/batch
+[batch]: https://batchdocs.web.cern.ch/
 [ipython-shell]: https://ipython.org/ipython-doc/3/interactive/tutorial.html
 [reverse-script]: code/01-managing-files-with-ganga/reverse.py


### PR DESCRIPTION
former URL: https://information-technology.web.cern.ch/services/batch returns 404 error. Another suitable URL which can be used here is used in replacement: https://batchdocs.web.cern.ch/