### PR TITLE
Update the DST name in several examples

### DIFF
--- a/first-analysis-steps/code/add-tupletools/ntuple_options_loki.py
+++ b/first-analysis-steps/code/add-tupletools/ntuple_options_loki.py
@@ -71,5 +71,5 @@ DaVinci().EvtMax = -1
 
 # Use the local input data
 IOHelper().inputFiles([
-    './00035742_00000002_1.allstreams.dst'
+    './00070793_00000001_7.AllStreams.dst'
 ], clear=True)

--- a/second-analysis-steps/code/12-add-tupletools/ntuple_options.py
+++ b/second-analysis-steps/code/12-add-tupletools/ntuple_options.py
@@ -37,5 +37,5 @@ DaVinci().EvtMax = -1
 
 # Use the local input data
 IOHelper().inputFiles([
-    './00035742_00000002_1.allstreams.dst'
+    './00070793_00000001_7.AllStreams.dst'
 ], clear=True)

--- a/second-analysis-steps/code/22-decay-tree-fitter/ntuple_DTF1.py
+++ b/second-analysis-steps/code/22-decay-tree-fitter/ntuple_DTF1.py
@@ -51,5 +51,5 @@ DaVinci().EvtMax = -1
 
 # Use the local input data
 IOHelper().inputFiles([
-    './00035742_00000002_1.allstreams.dst'
+    './00070793_00000001_7.AllStreams.dst'
 ], clear=True)


### PR DESCRIPTION
In some example scripts the name of the DST is outdated and does not match what's used in the earlier lessons, leading to a crash if executed blindly. 