### PR TITLE
Move lhcbsk paths to eos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.14
       - name: Install dependencies
         run: pip install -vv starterkit-ci>=0.1.0
       - name: Build the website

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.14
+          python-version: 3.13.1
       - name: Install dependencies
         run: pip install -vv starterkit-ci>=0.1.0
       - name: Build the website

--- a/conf.py
+++ b/conf.py
@@ -31,6 +31,7 @@ linkcheck_ignore += [
     r'https://twiki.cern.ch/.*',  # most pages now require a login
     r'https://opensource.org.*',  # 403 error - rejects the bot
     r'https://xrootd.slac.stanford.edu/doc/.*',  # redirect error - rejects the bot with SSL failure
+    r'https://sourceforge.net/.*', # 403 error - rejects the bot
 ]
 
 starterkit_ci_redirects['first-analysis-steps/index.html'] = 'https://lhcb.github.io/starterkit-lessons/first-analysis-steps/README.html'

--- a/first-analysis-steps/files-from-grid.md
+++ b/first-analysis-steps/files-from-grid.md
@@ -47,7 +47,7 @@ Lots of people downloading the same file at the same time can be very slow.
 As a workaround, the file is also available on EOS, and can be downloaded to
 your current directory with the following command:
 ```bash
-$ xrdcp root://eosuser.cern.ch//eos/user/l/lhcbsk/data-sets/00070793_00000001_7.AllStreams.dst .
+$ xrdcp root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/files-from-grid/00070793_00000001_7.AllStreams.dst .
 ```
 
 {% endcallout %} 

--- a/second-analysis-steps/rerun-stripping.md
+++ b/second-analysis-steps/rerun-stripping.md
@@ -27,7 +27,7 @@ Take a look at the file and try to find out what has changed compared to the [mi
 Lots of people downloading the same file at the same time can be very slow.
 The file in the minimal DaVinci example can be copied using this command:
 ```bash
-$ xrdcp root://eosuser.cern.ch//eos/user/l/lhcbsk/impactkit/00070793_00000001_7.AllStreams.dst .
+$ xrdcp root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/files-from-grid/00070793_00000001_7.AllStreams.dst .
 ```
 
 {% endcallout %}

--- a/second-analysis-steps/simulation-gencuts.md
+++ b/second-analysis-steps/simulation-gencuts.md
@@ -61,7 +61,7 @@ The second option is usually easier and in the example used so far only requires
 Generation().SignalPlain.CutTool = ""
 ```
 which must be included after `27163003.py` is sourced (e.g. in `Gauss-Job.py`). You can convince yourself that this alters the observed
-distributions and leads to a generator level cut efficiency of 100%. A large sample can be found on EOS: `root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/simulation/Gauss-27175000-modified-50000ev-20190515.xgen` (includes additional resonance added above).
+distributions and leads to a generator level cut efficiency of 100%. A large sample can be found on EOS: `root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/simulation/Gauss-27175000-modified-50000ev-20241216.xgen` (includes additional resonance added above).
 Have a look at the pseudorapidity distribution of the head particle. This illustrates another default behavior of the generation of signal decays in Gauss: The generated events' z-axis if inverted if the selected signal particle's momentum along that axis is negative.
 
 

--- a/second-analysis-steps/simulation-gencuts.md
+++ b/second-analysis-steps/simulation-gencuts.md
@@ -61,7 +61,7 @@ The second option is usually easier and in the example used so far only requires
 Generation().SignalPlain.CutTool = ""
 ```
 which must be included after `27163003.py` is sourced (e.g. in `Gauss-Job.py`). You can convince yourself that this alters the observed
-distributions and leads to a generator level cut efficiency of 100%. A large sample can be found on EOS: `root://eosuser.cern.ch//eos/user/l/lhcbsk/sim-lesson-2019/Gauss-27175000-modified-50000ev-20190515.xgen` (includes additional resonance added above).
+distributions and leads to a generator level cut efficiency of 100%. A large sample can be found on EOS: `root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/simulation/Gauss-27175000-modified-50000ev-20190515.xgen` (includes additional resonance added above).
 Have a look at the pseudorapidity distribution of the head particle. This illustrates another default behavior of the generation of signal decays in Gauss: The generated events' z-axis if inverted if the selected signal particle's momentum along that axis is negative.
 
 
@@ -96,7 +96,7 @@ tightCut.Cuts = {
    '[mu+]cc': 'inAcc'
 }
 ```
-You can again check that this works and a larger sample of 10,000 events can be found `root://eosuser.cern.ch//eos/user/l/lhcbsk/sim-lesson/GaussTightCut-27163003-10000ev.xgen`
+You can again check that this works and a larger sample of 10,000 events can be found `root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/simulation/GaussTightCut-27163003-10000ev.xgen`
 .
 You might also notice a slight slow-down in the rate at which events are produced: by default, 
 an event failing the generator cut (which is applied after Pythia and EvtGen are done) triggers a reset of

--- a/second-analysis-steps/simulation-gencuts.md
+++ b/second-analysis-steps/simulation-gencuts.md
@@ -96,7 +96,7 @@ tightCut.Cuts = {
    '[mu+]cc': 'inAcc'
 }
 ```
-You can again check that this works and a larger sample of 10,000 events can be found `root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/simulation/GaussTightCut-27163003-10000ev.xgen`
+You can again check that this works and a larger sample of 10,000 events can be found `root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/simulation/GaussTightCut-27175000-10000ev-20241216.xgen`
 .
 You might also notice a slight slow-down in the rate at which events are produced: by default, 
 an event failing the generator cut (which is applied after Pythia and EvtGen are done) triggers a reset of

--- a/second-analysis-steps/simulation-running-gauss.md
+++ b/second-analysis-steps/simulation-running-gauss.md
@@ -87,7 +87,7 @@ See if you can generate a generator level only sample for event type `27175000` 
 ## Make an nTuple
 
 The `.xgen` file can be processed into something more usable (copied together from [here](https://gitlab.cern.ch/lhcb-datapkg/Gen/DecFiles/blob/master/CONTRIBUTING.md#)).
-A larger input file containing 50,000 generated events for event-type can be found on EOS: `root://eosuser.cern.ch//eos/user/l/lhcbsk/sim-lesson-2019/Gauss-27175000-50000ev-20190515.xgen`.
+A larger input file containing 50,000 generated events for event-type can be found on EOS: `root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/simulation/Gauss-27175000-50000ev-20190515.xgen`.
 ```python
 """Configure the variables below with:
 decay: Decay you want to inspect, using 'newer' LoKi decay descriptor syntax,

--- a/second-analysis-steps/simulation-running-gauss.md
+++ b/second-analysis-steps/simulation-running-gauss.md
@@ -87,7 +87,7 @@ See if you can generate a generator level only sample for event type `27175000` 
 ## Make an nTuple
 
 The `.xgen` file can be processed into something more usable (copied together from [here](https://gitlab.cern.ch/lhcb-datapkg/Gen/DecFiles/blob/master/CONTRIBUTING.md#)).
-A larger input file containing 50,000 generated events for event-type can be found on EOS: `root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/simulation/Gauss-27175000-50000ev-20190515.xgen`.
+A larger input file containing 50,000 generated events for event-type can be found on EOS: `root://eoslhcb.cern.ch//eos/lhcb/wg/dpa/wp7/Run2SK/simulation/Gauss-27175000-50000ev-20241216.xgen`.
 ```python
 """Configure the variables below with:
 decay: Decay you want to inspect, using 'newer' LoKi decay descriptor syntax,


### PR DESCRIPTION
The `lhcbsk` user is being retired and the files which were (supposed to be) there are being moved to `eos`.

The files which were supposed to be there need to be recreated

 - [x] 00070793_00000001_7.AllStreams.dst
 - [x] Gauss-27175000-50000ev-20190515.xgen
 - [x] Gauss-27175000-modified-50000ev-20190515.xgen
 - [x] GaussTightCut-27163003-10000ev.xgen

These may be found in `/eos/lhcb/wg/dpa/wp7/Run2SK`