### PR TITLE
Fix links

### DIFF
--- a/first-analysis-steps/analysis-productions.md
+++ b/first-analysis-steps/analysis-productions.md
@@ -230,7 +230,7 @@ This will create `24c4_magdown_data` as a list of all the PFNs for the output of
 
 As mentioned earlier, your test productions for this lesson won't be merged since this is only for practice purposes. If this were a real production, there would be some extra steps to take before merging.
 
-You should try to reach out to anyone else who may also want to use these ntuples, and see if they'd like to add or change anything. This is usually done through your working group (either by email, or for new productions, by presenting at a WG meeting). For this, you can start by getting in touch with your WG conveners (see [here](http://lhcb.web.cern.ch/lhcb_page/collaboration/organization/lhcb-conv/Physics_history_and_Sub-structure.html) to find out who they are).
+You should try to reach out to anyone else who may also want to use these ntuples, and see if they'd like to add or change anything. This is usually done through your working group (either by email, or for new productions, by presenting at a WG meeting). For this, you can start by getting in touch with your WG conveners (see [here](https://twiki.cern.ch/twiki/bin/view/LHCbPhysics/LHCbPhysics) to find out who they are).
 
 In addition, the Analysis Productions coordinator(s) may also have some feedback on your additions/changes.
 

--- a/first-analysis-steps/analysisflow.md
+++ b/first-analysis-steps/analysisflow.md
@@ -78,7 +78,7 @@ Other corrections, like correcting the kinematics distributions in the simulated
 3. Computing efficiencies, acceptances and measuring detector resolution effects. 
 4. Putting all the above together to measure the parameter(s) of interest. 
 
-After acquiring the parameter(s) of interest, one has to have their work being reviewed by [physics working group](http://lhcb.web.cern.ch/lhcb_page/collaboration/organization/lhcb-conv/Physics_history_and_Sub-structure.html) (PWG) and then by the LHCb collaboration. 
+After acquiring the parameter(s) of interest, one has to have their work being reviewed by [physics working group](https://twiki.cern.ch/twiki/bin/view/LHCbPhysics/LHCbPhysics) (PWG) and then by the LHCb collaboration.
 
 One of the requirements for the successful review is that your analysis code is preserved.  
 Scientific integrity means having transparency on each step of the research as well as reproducibility of the results.


### PR DESCRIPTION
This link is now 404: http://lhcb.web.cern.ch/lhcb_page/collaboration/organization/lhcb-conv/Physics_history_and_Sub-structure.html

The info that used to be here is now here: https://twiki.cern.ch/twiki/bin/view/LHCbPhysics/LHCbPhysics